### PR TITLE
feat: add local storage and listen to enter keypress

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -208,17 +208,51 @@
                     offset: navHeight
                 });
 
-                const correctPassword = "f25";
+                const correctPasswordHash = "a149e84bc8b8e13e89f78c5ce4287eb27d73764d88b3d41056cc469e5dba4cf0";
 
-                function checkPassword() {
+                // Check if user is already authenticated on page load
+                window.addEventListener('load', function() {
+                    if (localStorage.getItem('authenticated') === 'true') {
+                        showProtectedContent();
+                    }
+                });
+
+                function showProtectedContent() {
+                    document.getElementById('password-prompt').style.display = 'none';
+                    document.getElementById('protected-content').style.display = 'block';
+                }
+
+                async function hashPassword(password) {
+                    const encoder = new TextEncoder();
+                    const data = encoder.encode(password);
+                    const hash = await crypto.subtle.digest('SHA-256', data);
+                    const hashArray = Array.from(new Uint8Array(hash));
+                    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+                }
+
+                async function checkPassword() {
                     const entered = document.getElementById('passwordInput').value;
-                    if (entered === correctPassword) {
-                        document.getElementById('password-prompt').style.display = 'none';
-                        document.getElementById('protected-content').style.display = 'block';
+                    const enteredHash = await hashPassword(entered);
+                    
+                    if (enteredHash === correctPasswordHash) {
+                        localStorage.setItem('authenticated', 'true');
+                        showProtectedContent();
                     } else {
                         document.getElementById('error').textContent = 'Incorrect password';
                     }
                 }
+
+                // Add Enter key support for password input
+                document.addEventListener('DOMContentLoaded', function() {
+                    const passwordInput = document.getElementById('passwordInput');
+                    if (passwordInput) {
+                        passwordInput.addEventListener('keypress', function(event) {
+                            if (event.key === 'Enter') {
+                                checkPassword();
+                            }
+                        });
+                    }
+                });
 
             </script>
     </body>


### PR DESCRIPTION
Hi @elizabethdinella ，

I've made some minor changes to our course website. In this PR, there are mainly three enhancements:

1. **Local storage login state**: The site now uses localStorage to persist the users' states, so users won't need to re-type the password every time clicking on a new page.
2. **Enter key support**: Add a event listener to "Enter" key press. After filling in the password, users can press enter to trigger password authentication.
3. **Hashed password**: The password is hashed, so it is not transmitted in plain text.

I have fully tested these features locally. If you have any questions or suggestions, please let me know.

Thank you!